### PR TITLE
fix(Navbar): make navbar usable on mobile

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,7 +25,7 @@ import { type LinkProps, Link, useColorMode, Box, Flex, IconButton, useColorMode
 import type { FC } from 'react';
 
 export const SunIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
     <path
       fillRule="evenodd"
       d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
@@ -37,7 +37,7 @@ export const SunIcon = () => (
 export const MoonIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    className="h-6 w-6"
+    className="h-4 w-4"
     fill="none"
     viewBox="0 0 24 24"
     stroke="currentColor"
@@ -83,19 +83,16 @@ const Navbar: FC = () => {
         w="100%"
         alignItems={{ base: 'center', lg: 'right' }}
         justifyContent={{ base: 'center', lg: 'right' }}
-        overflow="auto"
+        gap={{
+          base: '4',
+          lg: '12'
+        }}
       >
-        <NavLink href="/" mr="12">
-          Home
-        </NavLink>
+        <NavLink href="/">Home</NavLink>
 
-        <NavLink href="https://twitter.com/auguuwu" mr="12">
-          Twitter
-        </NavLink>
+        <NavLink href="https://twitter.com/auguuwu">Twitter</NavLink>
 
-        <NavLink href="https://github.com/auguwu" mr="12">
-          GitHub
-        </NavLink>
+        <NavLink href="https://github.com/auguwu">GitHub</NavLink>
 
         <IconButton
           aria-label="icon button"

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -23,12 +23,7 @@
 
 /* eslint-disable camelcase */
 
-import {
-  Container,
-  Center,
-  Heading,
-  Text,
-} from '@chakra-ui/react';
+import { Container, Center, Heading, Text } from '@chakra-ui/react';
 
 import { DateTime } from 'luxon';
 import Head from 'next/head';
@@ -67,9 +62,7 @@ export default function NotFound() {
             404
           </Heading>
 
-          <Text fontSize="x-large">
-            Page Not Found
-          </Text>
+          <Text fontSize="x-large">Page Not Found</Text>
         </Center>
       </Container>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,7 +126,13 @@ export default function MainPage() {
 
       <Container maxW={{ lg: '7xl', base: '3xl' }} rowGap="1em">
         <Center maxW="7xl" mt="2em" flexDirection="column" rowGap="1em" textAlign="center">
-          <Avatar src="https://cdn.floofy.dev/images/August.png" width="185px" height="185px" draggable="false" name="August">
+          <Avatar
+            src="https://cdn.floofy.dev/images/August.png"
+            width="185px"
+            height="185px"
+            draggable="false"
+            name="August"
+          >
             <AvatarBadge boxSize="50px" bg={statusColor} mb="0.95em" />
           </Avatar>
 


### PR DESCRIPTION
The previous Navbar would be cut off on the left side due to margins exceeding width, this change fixes that by giving a smaller space between the options on mobile.
![image](https://cdn.discordapp.com/attachments/890062342711300147/1036121636476309525/image0.jpg)
![image](http://roselyn.egg.lgbt/i/rz7qcpxb.png?raw=true)